### PR TITLE
update detective

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/thlorenz/rename-function-calls",
   "dependencies": {
-    "detective": "~3.1.0"
+    "detective": "~4.3.1"
   },
   "devDependencies": {
     "tap": "~0.4.3"


### PR DESCRIPTION
v3 depends on something that depends on something which depends on esprima-fb version 3001.0001.0000-dev-harmony-fb which breaks newer npm
